### PR TITLE
feat(hooks lint): replace hooks lint rule from react with custom one

### DIFF
--- a/config/eslint-base.js
+++ b/config/eslint-base.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['plugin:react/recommended'],
-  plugins: ['react-hooks'],
+  plugins: ['react-hooks', 'react-hooks-with-magic'],
 
   settings: {
     react: {
@@ -8,9 +8,9 @@ module.exports = {
     },
   },
   rules: {
+    'react-hooks-with-magic/exhaustive-deps': 'error',
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'error',
     'array-callback-return': ['error'],
     'consistent-return': ['error'],
     'default-case': ['error'],

--- a/config/eslint-base.js
+++ b/config/eslint-base.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['plugin:react/recommended'],
-  plugins: ['react-hooks', 'react-hooks-with-magic'],
+  plugins: ['react-hooks', 'react-hooks-breadhead'],
 
   settings: {
     react: {
@@ -8,7 +8,7 @@ module.exports = {
     },
   },
   rules: {
-    'react-hooks-with-magic/exhaustive-deps': 'error',
+    'react-hooks-breadhead/exhaustive-deps': 'error',
     'react/prop-types': 0,
     'react-hooks/rules-of-hooks': 'error',
     'array-callback-return': ['error'],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "5",
     "eslint-plugin-react": "7",
     "eslint-plugin-react-hooks": "1",
-    "eslint-plugin-react-hooks-with-magic": "^1.0.1",
+    "eslint-plugin-react-hooks-breadhead": "^1.0.0",
     "find": "0.2.9",
     "fs-extra": "^7.0.1",
     "husky": "1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "5",
     "eslint-plugin-react": "7",
     "eslint-plugin-react-hooks": "1",
+    "eslint-plugin-react-hooks-with-magic": "^1.0.1",
     "find": "0.2.9",
     "fs-extra": "^7.0.1",
     "husky": "1",


### PR DESCRIPTION
replaced exhaustive deps rule from react with custom one which omits fucntions named 'dispatch'
why? because we often use dispatch as a result of invocation of useThunk and we know that dispatch won't change, but eslint thinks that it's an error and make us disable exhaustive deps rule - therefore making it useless in our context
